### PR TITLE
feat: enforce single-column layout for mobile control panels (Issue #23)

### DIFF
--- a/components/ui/grouped-simulation-controls-panel.tsx
+++ b/components/ui/grouped-simulation-controls-panel.tsx
@@ -9,6 +9,7 @@ import CollapsibleControlGroup from './collapsible-control-group'
 import ViewportConstrainedPanel from './viewport-constrained-panel'
 import CompactColorPicker from './compact-color-picker'
 import CustomSelect from './custom-select'
+import { useMobileDetection } from '@/components/hooks/useMobileDetection'
 import type { PatternControl } from '@/components/pattern-generators/types'
 
 interface ControlGroup {
@@ -32,6 +33,8 @@ export default function GroupedSimulationControlsPanel({
   onControlChange,
   sidebarWidth
 }: GroupedSimulationControlsPanelProps) {
+  // AIDEV-NOTE: Mobile detection for consistent single-column layout on mobile devices (Issue #23)
+  const { isMobile } = useMobileDetection()
   
   const controlGroups = useMemo(() => {
     // Special case: cellular automaton always gets grouped for navigation layout
@@ -81,6 +84,7 @@ export default function GroupedSimulationControlsPanel({
     return (
       <ViewportConstrainedPanel paddingBuffer={paddingBuffer}>
         <div className={`grid gap-4 ${
+          isMobile ? 'grid-cols-1' : 
           sidebarWidth > 500 ? 'grid-cols-3' : 
           sidebarWidth > 400 ? 'grid-cols-2' : 
           'grid-cols-1'
@@ -145,6 +149,7 @@ export default function GroupedSimulationControlsPanel({
         {/* Render ungrouped controls (like reset buttons) at bottom */}
         {ungroupedControls.length > 0 && (
           <div className={`grid gap-4 ${
+            isMobile ? 'grid-cols-1' : 
             sidebarWidth > 500 ? 'grid-cols-3' : 
             sidebarWidth > 400 ? 'grid-cols-2' : 
             'grid-cols-1'


### PR DESCRIPTION
## Summary

- Mobile devices now consistently use single-column control layouts regardless of viewport width
- Improves touch interaction and readability on mobile devices  
- Preserves existing desktop responsive behavior and pattern-specific layouts

## Changes Made

- Added `useMobileDetection` hook to `GroupedSimulationControlsPanel`
- Modified grid layout logic to prioritize mobile detection over viewport width
- Mobile devices (≤767px) now always use `grid-cols-1` for better touch targets
- Desktop/tablet devices continue using existing responsive sidebar width logic

## Test Plan

- [x] Build and lint checks pass
- [x] Pattern-specific layouts preserved (four-pole gradient 2x2 color grids)
- [x] Desktop multi-column layouts work correctly
- [x] Mobile devices get consistent single-column layout

## Technical Details

**Files Modified:**
- `components/ui/grouped-simulation-controls-panel.tsx` - Added mobile detection logic

**Logic Changes:**
- Before: Grid columns based solely on `sidebarWidth` (caused >400px mobile devices to use 2-column layout)
- After: Mobile detection takes priority, forcing `grid-cols-1` on devices ≤767px

Fixes the issue where mobile devices with viewport width >400px incorrectly displayed controls in two-column layouts, making touch targets difficult to use.

🤖 Generated with [Claude Code](https://claude.ai/code)