### PR TITLE
Fix sidebar slide animation from right side (Issue #25)

### DIFF
--- a/components/mobile/mobile-layout-wrapper.tsx
+++ b/components/mobile/mobile-layout-wrapper.tsx
@@ -251,12 +251,15 @@ const MobileLayoutWrapper = memo(function MobileLayoutWrapper({
       </div>
 
       {/* Menu Overlay for mobile */}
-      {isMenuOpen && (
-        <div 
-          className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-300"
-          onClick={handleMenuToggle}
-        >
-          <div className="absolute top-0 right-0 w-64 h-full bg-background border-l border-border p-4 transform transition-transform duration-300 ease-in-out translate-x-0">
+      <div 
+        className={`fixed inset-0 z-50 bg-black/50 backdrop-blur-sm transition-opacity duration-300 ${
+          isMenuOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={handleMenuToggle}
+      >
+        <div className={`absolute top-0 right-0 w-64 h-full bg-background border-l border-border p-4 transform transition-transform duration-300 ease-in-out ${
+          isMenuOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}>
             <div className="flex items-center justify-between mb-6">
               <h2 className="font-mono text-sm uppercase tracking-wider">Menu</h2>
               <button 
@@ -281,8 +284,7 @@ const MobileLayoutWrapper = memo(function MobileLayoutWrapper({
             </div>
           </div>
         </div>
-      )}
-    </div>
+      </div>
   )
 })
 


### PR DESCRIPTION
## Summary
- Fixed mobile sidebar menu to slide smoothly from the right side instead of just appearing/disappearing instantly
- Replaced conditional rendering with always-present overlay to enable proper CSS transitions
- Sidebar now animates with translate-x-full (hidden) to translate-x-0 (visible) transforms

## Test plan
- [x] Mobile sidebar slides in smoothly from right when hamburger menu is tapped
- [x] Menu slides out to right when closed (backdrop tap or close button)  
- [x] Animation maintains 300ms ease-in-out timing
- [x] Backdrop overlay and close button functionality work correctly
- [x] Build passes with no TypeScript errors

🤖 Generated with [Claude Code](https://claude.ai/code)